### PR TITLE
ci: bump GO_VERSION to 1.26.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 permissions:
   contents: read
 env:
-  GO_VERSION: '1.25.x'
+  GO_VERSION: '1.26.x'
 
 jobs:
   lint:


### PR DESCRIPTION
## Why

The `urnetwork/connect` dependency bump in #81 raised the `go.mod` directive to `go 1.26.3` (toolchain `go1.26.5`). CI pins `GO_VERSION: '1.25.x'` and runs with `GOTOOLCHAIN=local`, so golangci-lint fails to load packages:

```
go: go.mod requires go >= 1.26.3 (running go 1.25.12; GOTOOLCHAIN=local)
golangci-lint exit with code 3
```

## What

Bump the single `GO_VERSION` env var (feeds all five `setup-go` steps) to `1.26.x`, which resolves to the latest 1.26 patch (≥ 1.26.5) — satisfying `go.mod`'s `go >= 1.26.3` and matching the existing `toolchain go1.26.5`.

## Effect

Unblocks the `lint` job and future Renovate dependency bumps. Once merged, Renovate rebases #81 and its lint job re-runs against `1.26.x`.